### PR TITLE
feat(ui): consume ZiggyUIPanels contract package

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Application-specific panels are now grouped behind a single boundary module:
 - `src/ui/panels/panels.zig`
 - `src/ui/panels/interfaces.zig` (panel runtime contract types: action + draw result)
 - `src/ui/panels/runtime.zig` (panel dispatch implementation used by main window)
+- `https://github.com/DeanoC/ZiggyUIPanels` (extracted contract package consumed by `ziggy-ui`)
 
 Internal callers should import panel implementations through that module instead of
 directly importing individual panel files. This is the extraction seam for moving

--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,11 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const ziggy_core_mod = ziggy_core_dep.module("ziggy-core");
+    const ziggy_ui_panels_dep = b.dependency("ziggy_ui_panels", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const ziggy_ui_panels_mod = ziggy_ui_panels_dep.module("ziggy-ui-panels");
 
     // Create the main ziggy-ui module
     const ziggy_ui_mod = b.addModule("ziggy-ui", .{
@@ -49,6 +54,7 @@ pub fn build(b: *std.Build) void {
     ziggy_ui_mod.addOptions("build_options", build_options);
     ziggy_ui_mod.addImport("ziggy-core", ziggy_core_mod);
     ziggy_ui_mod.addImport("zgpu", zgpu_dep.module("root"));
+    ziggy_ui_mod.addImport("ziggy-ui-panels", ziggy_ui_panels_mod);
 
     // Add SDL3 include path (SDL3 is a C library, not a Zig module)
     if (enable_sdl) {
@@ -90,6 +96,7 @@ pub fn build(b: *std.Build) void {
     test_mod.addOptions("build_options", build_options);
     test_mod.addImport("ziggy-core", ziggy_core_mod);
     test_mod.addImport("zgpu", zgpu_dep.module("root"));
+    test_mod.addImport("ziggy-ui-panels", ziggy_ui_panels_mod);
     if (enable_sdl) {
         test_mod.addIncludePath(sdl3_dep.path("include"));
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -18,6 +18,10 @@
             .url = "https://github.com/DeanoC/ziggy-core/archive/refs/heads/master.zip",
             .hash = "ziggy_core-0.1.0-q2d-rGiFAAA8ZiSbvWysW_gbVUJMoh-fGGn8PINTljE6",
         },
+        .ziggy_ui_panels = .{
+            .url = "https://github.com/DeanoC/ZiggyUIPanels/archive/refs/heads/main.tar.gz",
+            .hash = "ziggy_ui_panels-0.1.0-Zht7qftzAAC6W-8d2Evy8F1JyFFj38pkegDGpIbeeSnU",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/ui/panels/interfaces.zig
+++ b/src/ui/panels/interfaces.zig
@@ -2,9 +2,9 @@ const workspace = @import("../workspace.zig");
 const dock_graph = @import("../layout/dock_graph.zig");
 const operator_view = @import("../operator_view.zig");
 const agents_panel = @import("agents_panel.zig");
-const sessions_panel = @import("sessions_panel.zig");
+const panel_contract = @import("ziggy-ui-panels");
 
-pub const AttachmentOpen = sessions_panel.AttachmentOpen;
+pub const AttachmentOpen = panel_contract.AttachmentOpen;
 
 pub const SendMessageAction = struct {
     session_key: []u8,
@@ -74,7 +74,4 @@ pub const UiAction = struct {
     open_url: ?[]u8 = null,
 };
 
-pub const DrawResult = struct {
-    session_key: ?[]const u8 = null,
-    agent_id: ?[]const u8 = null,
-};
+pub const DrawResult = panel_contract.DrawResult;


### PR DESCRIPTION
## Summary
- add `ziggy_ui_panels` URL dependency in `build.zig.zon`
- wire `build.zig` to import `ziggy-ui-panels` into main/test modules
- switch `src/ui/panels/interfaces.zig` to consume `AttachmentOpen` and `DrawResult` from `ZiggyUIPanels`
- update docs to reference the extracted repo: https://github.com/DeanoC/ZiggyUIPanels

## Why
This is the first real cross-repo extraction step: panel contract types are now sourced from a standalone package while runtime implementation remains stable inside `ziggy-ui`.

## Validation
- zig build
- zig build test
