### PR TITLE
Rename project-oriented UI surfaces to workspace

### DIFF
--- a/src/ui/ide_menu.zig
+++ b/src/ui/ide_menu.zig
@@ -1,23 +1,23 @@
-// Compatibility shim for legacy IDE menu consumers.
+// Shared IDE menu contracts for workspace-first hosts.
 pub const IdeMenuDomain = enum {
     file,
     edit,
     view,
-    project,
+    workspace,
     tools,
     window,
     help,
 };
 
 pub const IdeMenuAction = enum {
-    file_new_project,
-    file_open_project,
-    file_switch_project,
+    file_new_workspace,
+    file_open_workspace,
+    file_switch_workspace,
     edit_undo,
     edit_redo,
     view_toggle_chat,
     view_toggle_explorer,
-    project_refresh,
+    workspace_refresh,
     tools_open_settings,
     window_new_window,
     help_about,
@@ -36,14 +36,14 @@ pub const IdeMenuModel = struct {
 
 pub fn defaultMenu() []const IdeMenuItem {
     return &[_]IdeMenuItem{
-        .{ .domain = .file, .action = .file_new_project, .label = "New Project" },
-        .{ .domain = .file, .action = .file_open_project, .label = "Open Project" },
-        .{ .domain = .file, .action = .file_switch_project, .label = "Switch Project" },
+        .{ .domain = .file, .action = .file_new_workspace, .label = "New Workspace" },
+        .{ .domain = .file, .action = .file_open_workspace, .label = "Open Workspace" },
+        .{ .domain = .file, .action = .file_switch_workspace, .label = "Switch Workspace" },
         .{ .domain = .edit, .action = .edit_undo, .label = "Undo" },
         .{ .domain = .edit, .action = .edit_redo, .label = "Redo" },
         .{ .domain = .view, .action = .view_toggle_chat, .label = "Chat" },
         .{ .domain = .view, .action = .view_toggle_explorer, .label = "Explorer" },
-        .{ .domain = .project, .action = .project_refresh, .label = "Refresh" },
+        .{ .domain = .workspace, .action = .workspace_refresh, .label = "Refresh Workspace" },
         .{ .domain = .tools, .action = .tools_open_settings, .label = "Settings" },
         .{ .domain = .window, .action = .window_new_window, .label = "New Window" },
         .{ .domain = .help, .action = .help_about, .label = "About" },

--- a/src/ui/launcher_shell.zig
+++ b/src/ui/launcher_shell.zig
@@ -1,11 +1,11 @@
-// Compatibility shim for legacy launcher-shell consumers.
+// Shared launcher-shell contracts for workspace-first hosts.
 pub const ConnectionProfileModel = struct {
     id: []const u8,
     name: []const u8,
     server_url: []const u8,
 };
 
-pub const ProjectCardModel = struct {
+pub const WorkspaceCardModel = struct {
     id: []const u8,
     name: []const u8,
     status: []const u8,
@@ -14,15 +14,15 @@ pub const ProjectCardModel = struct {
 pub const LauncherViewModel = struct {
     connected: bool = false,
     selected_profile_id: ?[]const u8 = null,
-    selected_project_id: ?[]const u8 = null,
+    selected_workspace_id: ?[]const u8 = null,
     profiles: []const ConnectionProfileModel = &.{},
-    projects: []const ProjectCardModel = &.{},
+    workspaces: []const WorkspaceCardModel = &.{},
 };
 
 pub const LauncherAction = union(enum) {
     none,
 };
 
-pub fn canOpenSelectedProject(view: *const LauncherViewModel) bool {
-    return view.connected and view.selected_profile_id != null and view.selected_project_id != null;
+pub fn canOpenSelectedWorkspace(view: *const LauncherViewModel) bool {
+    return view.connected and view.selected_profile_id != null and view.selected_workspace_id != null;
 }

--- a/src/ui/panel_manager.zig
+++ b/src/ui/panel_manager.zig
@@ -205,9 +205,9 @@ pub const PanelManager = struct {
                     if (panel.kind == .Control) return panel;
                 }
             },
-            .ProjectWorkspace => {
+            .WorkspaceOverview => {
                 for (self.workspace.panels.items) |*panel| {
-                    if (panel.kind == .ProjectWorkspace) return panel;
+                    if (panel.kind == .WorkspaceOverview) return panel;
                 }
             },
             .FilesystemBrowser => {
@@ -333,9 +333,9 @@ pub const PanelManager = struct {
                 const data = workspace.PanelData{ .Control = .{} };
                 return try self.openPanel(.Control, "Workspace", data);
             },
-            .ProjectWorkspace => {
-                const data = workspace.PanelData{ .ProjectWorkspace = {} };
-                return try self.openPanel(.ProjectWorkspace, "Projects", data);
+            .WorkspaceOverview => {
+                const data = workspace.PanelData{ .WorkspaceOverview = {} };
+                return try self.openPanel(.WorkspaceOverview, "Workspace Overview", data);
             },
             .FilesystemBrowser => {
                 const data = workspace.PanelData{ .FilesystemBrowser = {} };
@@ -684,7 +684,7 @@ pub const PanelManager = struct {
 fn parseControlTab(label: []const u8) workspace.ControlTab {
     if (std.mem.eql(u8, label, "Agents")) return .Agents;
     if (std.mem.eql(u8, label, "Inbox")) return .Inbox;
-    if (std.mem.eql(u8, label, "Projects")) return .Projects;
+    if (std.mem.eql(u8, label, "Workspaces")) return .Workspaces;
     if (std.mem.eql(u8, label, "Sources")) return .Sources;
     if (std.mem.eql(u8, label, "Artifact Workspace")) return .ArtifactWorkspace;
     if (std.mem.eql(u8, label, "Run Inspector")) return .RunInspector;

--- a/src/ui/panels/control_panel.zig
+++ b/src/ui/panels/control_panel.zig
@@ -98,7 +98,7 @@ pub fn draw(
     const tab_gap = t.spacing.xs;
     const tabs = [_]struct { label: []const u8, tab: workspace.ControlTab }{
         .{ .label = "Sessions", .tab = .Sessions },
-        .{ .label = "Projects", .tab = .Projects },
+        .{ .label = "Workspaces", .tab = .Workspaces },
         .{ .label = "Sources", .tab = .Sources },
     };
 
@@ -133,7 +133,7 @@ pub fn draw(
     }
 
     switch (panel.active_tab) {
-        .Projects => {
+        .Workspaces => {
             const projects_action = projects_view.draw(allocator, ctx, content_rect);
             action.refresh_sessions = projects_action.refresh_sessions;
             action.new_session = projects_action.new_session;

--- a/src/ui/panels/interfaces.zig
+++ b/src/ui/panels/interfaces.zig
@@ -393,67 +393,78 @@ pub const LauncherSettingsAction = union(enum) {
     restore_last,
 };
 
-pub const ProjectPanelModel = struct {
+pub const WorkspacePanelModel = struct {
     connected: bool = false,
-    has_projects: bool = false,
+    has_workspaces: bool = false,
     has_nodes: bool = false,
-    can_create_project: bool = false,
-    can_activate_project: bool = false,
-    can_lock_project: bool = false,
-    can_unlock_project: bool = false,
+    can_create_workspace: bool = false,
+    can_activate_workspace: bool = false,
+    can_attach_session: bool = false,
+    can_lock_workspace: bool = false,
+    can_unlock_workspace: bool = false,
 
-    pub fn controlsDisabled(self: ProjectPanelModel) bool {
+    pub fn controlsDisabled(self: WorkspacePanelModel) bool {
         return !self.connected;
     }
 };
 
-pub const ProjectListEntryView = struct {
+pub const WorkspaceListEntryView = struct {
     index: usize = 0,
     line: []const u8,
     selected: bool = false,
 };
 
-pub const ProjectNodeEntryView = struct {
+pub const WorkspaceNodeEntryView = struct {
     line: []const u8,
     degraded: bool = false,
 };
 
-pub const ProjectPanelView = struct {
-    title: []const u8 = "Project Workspace",
-    selected_project_button_label: []const u8 = "Select project",
-    lock_state_text: []const u8 = "Project lock state: unknown",
-    project_token: []const u8 = "",
+pub const WorkspacePanelView = struct {
+    title: []const u8 = "Workspace Overview",
+    selected_workspace_button_label: []const u8 = "Select workspace",
+    lock_state_text: []const u8 = "Workspace lock state: unknown",
+    workspace_token: []const u8 = "",
     create_name: []const u8 = "",
     create_vision: []const u8 = "",
+    template_id: []const u8 = "",
     operator_token: []const u8 = "",
     mount_path: []const u8 = "/",
     mount_node_id: []const u8 = "",
     mount_export_name: []const u8 = "",
+    bind_path: []const u8 = "/repo",
+    bind_target_path: []const u8 = "/nodes/local/fs",
     mount_hint: ?[]const u8 = null,
     workspace_error_text: ?[]const u8 = null,
-    selected_project_line: ?[]const u8 = null,
+    session_status_line: ?[]const u8 = null,
+    session_status_warning: bool = false,
+    selected_workspace_line: ?[]const u8 = null,
     setup_status_line: ?[]const u8 = null,
     setup_status_warning: bool = false,
     setup_vision_line: ?[]const u8 = null,
+    template_line: ?[]const u8 = null,
+    binds_line: ?[]const u8 = null,
     workspace_summary_line: ?[]const u8 = null,
     workspace_health_line: ?[]const u8 = null,
     workspace_health_warning: bool = false,
     workspace_health_error: bool = false,
     counts_line: ?[]const u8 = null,
     help_line: []const u8 = "Open Filesystem and Debug panels from the Windows menu.",
-    projects: []const ProjectListEntryView = &.{},
-    nodes: []const ProjectNodeEntryView = &.{},
+    workspaces: []const WorkspaceListEntryView = &.{},
+    nodes: []const WorkspaceNodeEntryView = &.{},
 };
 
-pub const ProjectPanelAction = union(enum) {
-    select_project_index: usize,
-    create_project,
+pub const WorkspacePanelAction = union(enum) {
+    select_workspace_index: usize,
+    create_workspace,
     refresh_workspace,
-    activate_project,
-    lock_project,
-    unlock_project,
+    activate_workspace,
+    attach_session,
+    lock_workspace,
+    unlock_workspace,
     add_mount,
     remove_mount,
+    add_bind,
+    remove_bind,
     auth_status,
     rotate_auth_user,
     rotate_auth_admin,
@@ -549,11 +560,11 @@ test "LauncherSettingsModel helper gates match connection state" {
     try std.testing.expect(connected.canRunConnectedActions());
 }
 
-test "ProjectPanelModel helper gates match connection state" {
-    const disconnected = ProjectPanelModel{};
+test "WorkspacePanelModel helper gates match connection state" {
+    const disconnected = WorkspacePanelModel{};
     try std.testing.expect(disconnected.controlsDisabled());
 
-    const connected = ProjectPanelModel{ .connected = true };
+    const connected = WorkspacePanelModel{ .connected = true };
     try std.testing.expect(!connected.controlsDisabled());
 }
 

--- a/src/ui/panels/runtime.zig
+++ b/src/ui/panels/runtime.zig
@@ -42,7 +42,7 @@ pub const HostPanelAdapter = struct {
     ) void,
 };
 pub const HostPanelRegistry = struct {
-    project_workspace: ?HostPanelAdapter = null,
+    workspace_overview: ?HostPanelAdapter = null,
     filesystem_browser: ?HostPanelAdapter = null,
     filesystem_tools: ?HostPanelAdapter = null,
     debug_stream: ?HostPanelAdapter = null,
@@ -57,7 +57,7 @@ pub const HostPanelRegistry = struct {
         pending_attachment: *?AttachmentOpen,
     ) bool {
         const maybe_adapter: ?HostPanelAdapter = switch (panel.kind) {
-            .ProjectWorkspace => self.project_workspace,
+            .WorkspaceOverview => self.workspace_overview,
             .FilesystemBrowser => self.filesystem_browser,
             .FilesystemTools => self.filesystem_tools,
             .DebugStream => self.debug_stream,
@@ -79,11 +79,11 @@ pub fn drawHostPanel(
     host_panels: ?*const HostPanelRegistry,
 ) bool {
     switch (panel.kind) {
-        .ProjectWorkspace => {
+        .WorkspaceOverview => {
             if (host_panels) |value| {
                 if (value.draw(panel, allocator, panel_rect, manager, action, pending_attachment)) return true;
             }
-            drawHostInterceptPanelPlaceholder(allocator, panel, panel_rect, "Project workspace view is provided by the host app.");
+            drawHostInterceptPanelPlaceholder(allocator, panel, panel_rect, "Workspace overview is provided by the host app.");
             return true;
         },
         .FilesystemBrowser => {
@@ -266,7 +266,7 @@ pub fn drawContentsWithHost(
         .ToolOutput => {
             tool_output_panel.draw(panel, allocator, panel_rect);
         },
-        .ProjectWorkspace => {
+        .WorkspaceOverview => {
             _ = drawHostPanel(allocator, panel, panel_rect, manager, action, pending_attachment, host_panels);
         },
         .FilesystemBrowser => {
@@ -346,7 +346,16 @@ pub fn drawContentsWithHost(
             }
             replaceOwnedSlice(allocator, &action.clear_node_describe, control_action.clear_node_describe);
             if (control_action.open_attachment) |attachment| {
-                pending_attachment.* = attachment;
+                pending_attachment.* = .{
+                    .name = allocator.dupe(u8, attachment.name) catch return result,
+                    .kind = allocator.dupe(u8, attachment.kind) catch return result,
+                    .url = allocator.dupe(u8, attachment.url) catch return result,
+                    .role = allocator.dupe(u8, attachment.role) catch return result,
+                    .timestamp = attachment.timestamp,
+                    .body = null,
+                    .status = null,
+                    .truncated = false,
+                };
             }
             replaceOwnedSlice(allocator, &action.select_session, control_action.select_session);
             if (control_action.select_session != null) {
@@ -564,11 +573,11 @@ fn mergeSettingsPanelAction(action: *UiAction, settings_action: anytype) void {
 }
 
 const HostPanelDispatchTestCtx = struct {
-    project_calls: u8 = 0,
+    workspace_overview_calls: u8 = 0,
     filesystem_calls: u8 = 0,
     debug_calls: u8 = 0,
 
-    fn onProject(
+    fn onWorkspaceOverview(
         ctx: *anyopaque,
         allocator: std.mem.Allocator,
         panel: *workspace.Panel,
@@ -584,7 +593,7 @@ const HostPanelDispatchTestCtx = struct {
         _ = action;
         _ = pending_attachment;
         const typed: *HostPanelDispatchTestCtx = @ptrCast(@alignCast(ctx));
-        typed.project_calls += 1;
+        typed.workspace_overview_calls += 1;
     }
 
     fn onFilesystem(
@@ -633,7 +642,7 @@ test "drawHostPanel dispatches host adapters by panel kind" {
 
     var test_ctx = HostPanelDispatchTestCtx{};
     const registry = HostPanelRegistry{
-        .project_workspace = .{ .ctx = @ptrCast(&test_ctx), .draw_fn = HostPanelDispatchTestCtx.onProject },
+        .workspace_overview = .{ .ctx = @ptrCast(&test_ctx), .draw_fn = HostPanelDispatchTestCtx.onWorkspaceOverview },
         .filesystem_browser = .{ .ctx = @ptrCast(&test_ctx), .draw_fn = HostPanelDispatchTestCtx.onFilesystem },
         .debug_stream = .{ .ctx = @ptrCast(&test_ctx), .draw_fn = HostPanelDispatchTestCtx.onDebug },
     };
@@ -641,17 +650,17 @@ test "drawHostPanel dispatches host adapters by panel kind" {
     var action: UiAction = .{};
     var pending_attachment: ?AttachmentOpen = null;
 
-    var project_panel = workspace.Panel{
+    var workspace_overview_panel = workspace.Panel{
         .id = 1,
-        .kind = .ProjectWorkspace,
-        .title = try allocator.dupe(u8, "Projects"),
-        .data = .{ .ProjectWorkspace = {} },
+        .kind = .WorkspaceOverview,
+        .title = try allocator.dupe(u8, "Workspace Overview"),
+        .data = .{ .WorkspaceOverview = {} },
         .state = .{},
     };
-    defer project_panel.deinit(allocator);
+    defer workspace_overview_panel.deinit(allocator);
     try std.testing.expect(drawHostPanel(
         allocator,
-        &project_panel,
+        &workspace_overview_panel,
         null,
         &manager,
         &action,
@@ -695,7 +704,7 @@ test "drawHostPanel dispatches host adapters by panel kind" {
         &registry,
     ));
 
-    try std.testing.expectEqual(@as(u8, 1), test_ctx.project_calls);
+    try std.testing.expectEqual(@as(u8, 1), test_ctx.workspace_overview_calls);
     try std.testing.expectEqual(@as(u8, 1), test_ctx.filesystem_calls);
     try std.testing.expectEqual(@as(u8, 1), test_ctx.debug_calls);
 }
@@ -711,9 +720,9 @@ test "drawHostPanel reports handled only for host panel kinds" {
 
     var host_panel = workspace.Panel{
         .id = 10,
-        .kind = .ProjectWorkspace,
-        .title = try allocator.dupe(u8, "Projects"),
-        .data = .{ .ProjectWorkspace = {} },
+        .kind = .WorkspaceOverview,
+        .title = try allocator.dupe(u8, "Workspace Overview"),
+        .data = .{ .WorkspaceOverview = {} },
         .state = .{},
     };
     defer host_panel.deinit(allocator);

--- a/src/ui/theme_engine/theme_engine.zig
+++ b/src/ui/theme_engine/theme_engine.zig
@@ -989,7 +989,7 @@ pub const ThemeEngine = struct {
         if (std.ascii.eqlIgnoreCase(label, "workspace") or std.ascii.eqlIgnoreCase(label, "control")) return .Control;
         if (std.ascii.eqlIgnoreCase(label, "chat")) return .Chat;
         if (std.ascii.eqlIgnoreCase(label, "agents")) return .Agents;
-        if (std.ascii.eqlIgnoreCase(label, "projects") or std.ascii.eqlIgnoreCase(label, "projectworkspace") or std.ascii.eqlIgnoreCase(label, "project_workspace")) return .ProjectWorkspace;
+        if (std.ascii.eqlIgnoreCase(label, "workspace overview") or std.ascii.eqlIgnoreCase(label, "workspaceoverview") or std.ascii.eqlIgnoreCase(label, "workspace_overview")) return .WorkspaceOverview;
         if (std.ascii.eqlIgnoreCase(label, "filesystem") or std.ascii.eqlIgnoreCase(label, "filesystembrowser") or std.ascii.eqlIgnoreCase(label, "filesystem_browser")) return .FilesystemBrowser;
         if (std.ascii.eqlIgnoreCase(label, "filesystemtools") or std.ascii.eqlIgnoreCase(label, "filesystem_tools") or std.ascii.eqlIgnoreCase(label, "filesystem tools")) return .FilesystemTools;
         if (std.ascii.eqlIgnoreCase(label, "debug") or std.ascii.eqlIgnoreCase(label, "debugstream") or std.ascii.eqlIgnoreCase(label, "debug_stream")) return .DebugStream;

--- a/src/ui/ui_command.zig
+++ b/src/ui/ui_command.zig
@@ -43,7 +43,7 @@ pub const PanelDataPayload = union(enum) {
     Chat: ChatPanelPayload,
     CodeEditor: CodeEditorPanelPayload,
     ToolOutput: ToolOutputPanelPayload,
-    ProjectWorkspace: void,
+    WorkspaceOverview: void,
     FilesystemBrowser: void,
     FilesystemTools: void,
     DebugStream: void,
@@ -72,7 +72,7 @@ pub const PanelDataPayload = union(enum) {
                 if (out.stdout) |stdout| allocator.free(stdout);
                 if (out.stderr) |stderr| allocator.free(stderr);
             },
-            .ProjectWorkspace => {},
+            .WorkspaceOverview => {},
             .FilesystemBrowser => {},
             .FilesystemTools => {},
             .DebugStream => {},
@@ -183,7 +183,7 @@ fn parseOpen(allocator: std.mem.Allocator, obj: std.json.ObjectMap) !?UiCommand 
                 .exit_code = exit_code,
             } };
         },
-        .ProjectWorkspace => PanelDataPayload{ .ProjectWorkspace = {} },
+        .WorkspaceOverview => PanelDataPayload{ .WorkspaceOverview = {} },
         .FilesystemBrowser => PanelDataPayload{ .FilesystemBrowser = {} },
         .FilesystemTools => PanelDataPayload{ .FilesystemTools = {} },
         .DebugStream => PanelDataPayload{ .DebugStream = {} },
@@ -293,7 +293,7 @@ fn parseDataPayloadForKind(
             if (!allow_partial and tool_name == null) return error.MissingPanelData;
             return .{ .ToolOutput = .{ .tool_name = tool_name, .stdout = stdout, .stderr = stderr, .exit_code = exit_code } };
         },
-        .ProjectWorkspace => return .{ .ProjectWorkspace = {} },
+        .WorkspaceOverview => return .{ .WorkspaceOverview = {} },
         .FilesystemBrowser => return .{ .FilesystemBrowser = {} },
         .FilesystemTools => return .{ .FilesystemTools = {} },
         .DebugStream => return .{ .DebugStream = {} },
@@ -325,11 +325,11 @@ fn parsePanelKind(label: []const u8) ?workspace.PanelKind {
     if (std.mem.eql(u8, label, "Chat")) return .Chat;
     if (std.mem.eql(u8, label, "CodeEditor")) return .CodeEditor;
     if (std.mem.eql(u8, label, "ToolOutput")) return .ToolOutput;
-    if (std.mem.eql(u8, label, "ProjectWorkspace")) return .ProjectWorkspace;
+    if (std.mem.eql(u8, label, "WorkspaceOverview")) return .WorkspaceOverview;
     if (std.mem.eql(u8, label, "FilesystemBrowser")) return .FilesystemBrowser;
     if (std.mem.eql(u8, label, "FilesystemTools")) return .FilesystemTools;
     if (std.mem.eql(u8, label, "DebugStream")) return .DebugStream;
-    if (std.mem.eql(u8, label, "Projects")) return .ProjectWorkspace;
+    if (std.mem.eql(u8, label, "Workspace Overview")) return .WorkspaceOverview;
     if (std.mem.eql(u8, label, "Filesystem")) return .FilesystemBrowser;
     if (std.mem.eql(u8, label, "Filesystem Tools")) return .FilesystemTools;
     if (std.mem.eql(u8, label, "Debug")) return .DebugStream;

--- a/src/ui/workspace.zig
+++ b/src/ui/workspace.zig
@@ -10,13 +10,13 @@ const WorkspaceChatView = chat_view.ChatView(types.ChatMessage);
 
 pub const PanelId = u64;
 pub const DockNodeId = u32;
-pub const ProjectId = u64;
+pub const WorkspaceId = u64;
 
 pub const PanelKind = enum {
     Chat,
     CodeEditor,
     ToolOutput,
-    ProjectWorkspace,
+    WorkspaceOverview,
     FilesystemBrowser,
     FilesystemTools,
     DebugStream,
@@ -89,7 +89,7 @@ pub const ControlPanel = struct {
 pub const ControlTab = enum {
     Agents,
     Inbox,
-    Projects,
+    Workspaces,
     Sources,
     ArtifactWorkspace,
     RunInspector,
@@ -106,7 +106,7 @@ pub const PanelData = union(enum) {
     Chat: ChatPanel,
     CodeEditor: CodeEditorPanel,
     ToolOutput: ToolOutputPanel,
-    ProjectWorkspace: void,
+    WorkspaceOverview: void,
     FilesystemBrowser: void,
     FilesystemTools: void,
     DebugStream: void,
@@ -150,7 +150,7 @@ pub const PanelData = union(enum) {
                 out.stdout_editor = null;
                 out.stderr_editor = null;
             },
-            .ProjectWorkspace => {},
+            .WorkspaceOverview => {},
             .FilesystemBrowser => {},
             .FilesystemTools => {},
             .DebugStream => {},
@@ -191,7 +191,7 @@ pub const Workspace = struct {
     custom_layout: CustomLayoutState,
     dock_layout: dock_graph.Graph,
     focused_panel_id: ?PanelId,
-    active_project: ProjectId,
+    active_workspace: WorkspaceId,
     dirty: bool = false,
 
     pub fn initEmpty(allocator: std.mem.Allocator) Workspace {
@@ -200,7 +200,7 @@ pub const Workspace = struct {
             .custom_layout = .{},
             .dock_layout = dock_graph.Graph.init(allocator),
             .focused_panel_id = null,
-            .active_project = 0,
+            .active_workspace = 0,
             .dirty = false,
         };
     }
@@ -257,7 +257,7 @@ pub const Workspace = struct {
             filled = idx + 1;
         }
         return .{
-            .active_project = self.active_project,
+            .active_workspace = self.active_workspace,
             .focused_panel_id = self.focused_panel_id,
             .next_panel_id = max_id + 1,
             .custom_layout = .{
@@ -273,7 +273,7 @@ pub const Workspace = struct {
 
     pub fn fromSnapshot(allocator: std.mem.Allocator, snapshot: WorkspaceSnapshot) !Workspace {
         var ws = Workspace.initEmpty(allocator);
-        ws.active_project = snapshot.active_project;
+        ws.active_workspace = snapshot.active_workspace;
         ws.focused_panel_id = snapshot.focused_panel_id;
 
         if (snapshot.custom_layout) |layout| {
@@ -411,7 +411,7 @@ pub const PanelSnapshot = struct {
 };
 
 pub const WorkspaceSnapshot = struct {
-    active_project: ProjectId = 0,
+    active_workspace: WorkspaceId = 0,
     focused_panel_id: ?PanelId = null,
     next_panel_id: PanelId = 1,
     custom_layout: ?CustomLayoutSnapshot = null,
@@ -458,7 +458,7 @@ pub const DetachedWindowSnapshot = struct {
     pixel_snap_textured: ?bool = null,
 
     // Workspace-ish state for this window.
-    active_project: ProjectId = 0,
+    active_workspace: WorkspaceId = 0,
     focused_panel_id: ?PanelId = null,
     custom_layout: ?CustomLayoutSnapshot = null,
     layout_version: u32 = 1,
@@ -532,7 +532,7 @@ fn panelToSnapshot(allocator: std.mem.Allocator, panel: Panel) !PanelSnapshot {
                 .exit_code = out.exit_code,
             };
         },
-        .ProjectWorkspace => {},
+        .WorkspaceOverview => {},
         .FilesystemBrowser => {},
         .FilesystemTools => {},
         .DebugStream => {},
@@ -541,7 +541,7 @@ fn panelToSnapshot(allocator: std.mem.Allocator, panel: Panel) !PanelSnapshot {
                 .active_tab = try allocator.dupe(u8, switch (ctrl.active_tab) {
                     .Agents => "Agents",
                     .Inbox => "Inbox",
-                    .Projects => "Projects",
+                    .Workspaces => "Workspaces",
                     .Sources => "Sources",
                     .ArtifactWorkspace => "Artifact Workspace",
                     .RunInspector => "Run Inspector",
@@ -662,12 +662,12 @@ fn panelFromSnapshot(allocator: std.mem.Allocator, snap: PanelSnapshot) !Panel {
                 .state = state_val,
             };
         },
-        .ProjectWorkspace => {
+        .WorkspaceOverview => {
             return .{
                 .id = snap.id,
-                .kind = .ProjectWorkspace,
+                .kind = .WorkspaceOverview,
                 .title = title_copy,
-                .data = .{ .ProjectWorkspace = {} },
+                .data = .{ .WorkspaceOverview = {} },
                 .state = state_val,
             };
         },
@@ -798,7 +798,7 @@ fn panelFromSnapshot(allocator: std.mem.Allocator, snap: PanelSnapshot) !Panel {
 fn parseControlTab(label: []const u8) ControlTab {
     if (std.mem.eql(u8, label, "Agents")) return .Agents;
     if (std.mem.eql(u8, label, "Inbox")) return .Inbox;
-    if (std.mem.eql(u8, label, "Projects")) return .Projects;
+    if (std.mem.eql(u8, label, "Workspaces")) return .Workspaces;
     if (std.mem.eql(u8, label, "Sources")) return .Sources;
     if (std.mem.eql(u8, label, "Artifact Workspace")) return .ArtifactWorkspace;
     if (std.mem.eql(u8, label, "Run Inspector")) return .RunInspector;
@@ -916,13 +916,13 @@ pub fn makeToolOutputPanel(
     };
 }
 
-pub fn makeProjectWorkspacePanel(allocator: std.mem.Allocator, id: PanelId) !Panel {
-    const title = try allocator.dupe(u8, "Projects");
+pub fn makeWorkspaceOverviewPanel(allocator: std.mem.Allocator, id: PanelId) !Panel {
+    const title = try allocator.dupe(u8, "Workspace Overview");
     return .{
         .id = id,
-        .kind = .ProjectWorkspace,
+        .kind = .WorkspaceOverview,
         .title = title,
-        .data = .{ .ProjectWorkspace = {} },
+        .data = .{ .WorkspaceOverview = {} },
         .state = .{},
     };
 }

--- a/src/ui/workspace_store.zig
+++ b/src/ui/workspace_store.zig
@@ -289,7 +289,7 @@ pub fn loadMultiOrDefault(allocator: std.mem.Allocator, path: []const u8) !Multi
         errdefer if (sampling_copy) |p| allocator.free(p);
 
         const tmp_snap = workspace.WorkspaceSnapshot{
-            .active_project = wsrc.active_project,
+            .active_workspace = wsrc.active_workspace,
             .focused_panel_id = wsrc.focused_panel_id,
             .next_panel_id = snap.next_panel_id,
             .custom_layout = wsrc.custom_layout,
@@ -403,7 +403,7 @@ pub fn saveMulti(
                 .variant = variant_copy,
                 .image_sampling = sampling_copy,
                 .pixel_snap_textured = w.pixel_snap_textured,
-                .active_project = ws_snap.active_project,
+                .active_workspace = ws_snap.active_workspace,
                 .focused_panel_id = ws_snap.focused_panel_id,
                 .custom_layout = ws_snap.custom_layout,
                 .layout_version = ws_snap.layout_version,


### PR DESCRIPTION
## Summary
- rename the shared project-oriented panel/menu/runtime contracts to workspace terminology
- update launcher and workspace shell surfaces to use workspace-first naming
- keep the shared UI package aligned with SpiderApp's workspace overview flow

## Testing
- not run separately in this repo; validated via SpiderApp `zig build`, `zig build gui`, and `zig build test`
