### PR TITLE
feat(android): add renderer and surface support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,7 @@ pub fn build(b: *std.Build) void {
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const build_native_artifacts = !target.result.abi.isAndroid();
 
     // Options for backend selection
     const enable_wgpu = b.option(bool, "wgpu", "Enable WGPU renderer backend") orelse true;
@@ -72,87 +73,89 @@ pub fn build(b: *std.Build) void {
         ziggy_ui_mod.addIncludePath(freetype_dep.path("include"));
     }
 
-    // Create static library
-    const lib = b.addLibrary(.{
-        .name = "ziggy-ui",
-        .root_module = ziggy_ui_mod,
-        .linkage = .static,
-    });
+    if (build_native_artifacts) {
+        // Create static library
+        const lib = b.addLibrary(.{
+            .name = "ziggy-ui",
+            .root_module = ziggy_ui_mod,
+            .linkage = .static,
+        });
 
-    // Link SDL3
-    if (enable_sdl) {
-        lib.linkLibrary(sdl3_dep.artifact("SDL3"));
-    }
+        // Link SDL3
+        if (enable_sdl) {
+            lib.linkLibrary(sdl3_dep.artifact("SDL3"));
+        }
 
-    // Link freetype
-    if (enable_freetype) {
-        lib.linkLibrary(freetype_dep.artifact("freetype"));
-    }
+        // Link freetype
+        if (enable_freetype) {
+            lib.linkLibrary(freetype_dep.artifact("freetype"));
+        }
 
-    b.installArtifact(lib);
+        b.installArtifact(lib);
 
-    // Tests
-    const test_step = b.step("test", "Run ziggy-ui tests");
+        // Tests
+        const test_step = b.step("test", "Run ziggy-ui tests");
 
-    const test_mod = b.createModule(.{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    test_mod.addOptions("build_options", build_options);
-    test_mod.addImport("ziggy-core", ziggy_core_mod);
-    test_mod.addImport("zgpu", zgpu_dep.module("root"));
-    if (enable_sdl) {
-        test_mod.addIncludePath(sdl3_dep.path("include"));
-    }
-    if (enable_freetype) {
-        test_mod.addIncludePath(freetype_dep.path("include"));
-    }
-
-    const tests = b.addTest(.{
-        .root_module = test_mod,
-    });
-    if (enable_sdl) {
-        tests.linkLibrary(sdl3_dep.artifact("SDL3"));
-    }
-    if (enable_freetype) {
-        tests.linkLibrary(freetype_dep.artifact("freetype"));
-    }
-    const run_tests = b.addRunArtifact(tests);
-    test_step.dependOn(&run_tests.step);
-
-    const build_examples = b.option(bool, "build-examples", "Build ziggy-ui examples") orelse false;
-    if (build_examples) {
-        // Example: basic
-        const example_mod = b.createModule(.{
-            .root_source_file = b.path("examples/basic.zig"),
+        const test_mod = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
             .target = target,
             .optimize = optimize,
         });
-        example_mod.addImport("ziggy-ui", ziggy_ui_mod);
-        example_mod.addImport("ziggy-core", ziggy_core_mod);
-        example_mod.addImport("zgpu", zgpu_dep.module("root"));
+        test_mod.addOptions("build_options", build_options);
+        test_mod.addImport("ziggy-core", ziggy_core_mod);
+        test_mod.addImport("zgpu", zgpu_dep.module("root"));
         if (enable_sdl) {
-            example_mod.addIncludePath(sdl3_dep.path("include"));
+            test_mod.addIncludePath(sdl3_dep.path("include"));
         }
         if (enable_freetype) {
-            example_mod.addIncludePath(freetype_dep.path("include"));
+            test_mod.addIncludePath(freetype_dep.path("include"));
         }
 
-        const example_basic = b.addExecutable(.{
-            .name = "example-basic",
-            .root_module = example_mod,
+        const tests = b.addTest(.{
+            .root_module = test_mod,
         });
         if (enable_sdl) {
-            example_basic.linkLibrary(sdl3_dep.artifact("SDL3"));
+            tests.linkLibrary(sdl3_dep.artifact("SDL3"));
         }
         if (enable_freetype) {
-            example_basic.linkLibrary(freetype_dep.artifact("freetype"));
+            tests.linkLibrary(freetype_dep.artifact("freetype"));
         }
-        b.installArtifact(example_basic);
+        const run_tests = b.addRunArtifact(tests);
+        test_step.dependOn(&run_tests.step);
 
-        const run_example = b.addRunArtifact(example_basic);
-        const example_step = b.step("example-basic", "Run the basic example");
-        example_step.dependOn(&run_example.step);
+        const build_examples = b.option(bool, "build-examples", "Build ziggy-ui examples") orelse false;
+        if (build_examples) {
+            // Example: basic
+            const example_mod = b.createModule(.{
+                .root_source_file = b.path("examples/basic.zig"),
+                .target = target,
+                .optimize = optimize,
+            });
+            example_mod.addImport("ziggy-ui", ziggy_ui_mod);
+            example_mod.addImport("ziggy-core", ziggy_core_mod);
+            example_mod.addImport("zgpu", zgpu_dep.module("root"));
+            if (enable_sdl) {
+                example_mod.addIncludePath(sdl3_dep.path("include"));
+            }
+            if (enable_freetype) {
+                example_mod.addIncludePath(freetype_dep.path("include"));
+            }
+
+            const example_basic = b.addExecutable(.{
+                .name = "example-basic",
+                .root_module = example_mod,
+            });
+            if (enable_sdl) {
+                example_basic.linkLibrary(sdl3_dep.artifact("SDL3"));
+            }
+            if (enable_freetype) {
+                example_basic.linkLibrary(freetype_dep.artifact("freetype"));
+            }
+            b.installArtifact(example_basic);
+
+            const run_example = b.addRunArtifact(example_basic);
+            const example_step = b.step("example-basic", "Run the basic example");
+            example_step.dependOn(&run_example.step);
+        }
     }
 }

--- a/deps/zgpu/src/wgpu.zig
+++ b/deps/zgpu/src/wgpu.zig
@@ -383,6 +383,11 @@ pub const SurfaceDescriptorFromXlibWindow = extern struct {
     window: u32,
 };
 
+pub const SurfaceDescriptorFromAndroidNativeWindow = extern struct {
+    chain: ChainedStruct,
+    window: *anyopaque,
+};
+
 pub const SurfaceDescriptorFromWindowsCoreWindow = extern struct {
     chain: ChainedStruct,
     core_window: *anyopaque,

--- a/deps/zgpu/src/zgpu.zig
+++ b/deps/zgpu/src/zgpu.zig
@@ -85,7 +85,10 @@ pub const GraphicsContextOptions = struct {
 };
 
 pub const GraphicsContext = struct {
-    pub const swapchain_format = wgpu.TextureFormat.bgra8_unorm;
+    pub const swapchain_format = if (@import("builtin").target.abi.isAndroid())
+        wgpu.TextureFormat.rgba8_unorm
+    else
+        wgpu.TextureFormat.bgra8_unorm;
 
     window_provider: WindowProvider,
 
@@ -131,8 +134,17 @@ pub const GraphicsContext = struct {
 
         const native_instance = if (!emscripten) dniCreate();
         errdefer if (!emscripten) dniDestroy(native_instance);
+        if (!emscripten) {
+            dniDiscoverDefaultAdapters(native_instance);
+        }
 
-        const instance = if (emscripten) wgpu.createInstance(.{}) else dniGetWgpuInstance(native_instance).?;
+        const instance = if (emscripten)
+            wgpu.createInstance(.{})
+        else
+            dniGetWgpuInstance(native_instance) orelse {
+                std.log.err("[zgpu] create: Dawn instance was null", .{});
+                return error.NoGraphicsInstance;
+            };
 
         const adapter = adapter: {
             const Response = struct {
@@ -155,8 +167,15 @@ pub const GraphicsContext = struct {
             }).callback;
 
             var response = Response{};
+            const adapter_options = if (@import("builtin").target.abi.isAndroid())
+                wgpu.RequestAdapterOptions{
+                    .power_preference = .high_performance,
+                    .backend_type = .vulkan,
+                }
+            else
+                wgpu.RequestAdapterOptions{ .power_preference = .high_performance };
             instance.requestAdapter(
-                .{ .power_preference = .high_performance },
+                adapter_options,
                 callback,
                 @ptrCast(&response),
             );
@@ -259,7 +278,7 @@ pub const GraphicsContext = struct {
 
         device.setUncapturedErrorCallback(logUnhandledError, null);
 
-        const surface = createSurfaceForWindow(instance, window_provider);
+        const surface = try createSurfaceForWindow(instance, window_provider);
         errdefer surface.release();
 
         const framebuffer_size = window_provider.getFramebufferSize();
@@ -1132,6 +1151,7 @@ const DawnNativeInstance = ?*opaque {};
 const DawnProcsTable = ?*opaque {};
 extern fn dniCreate() DawnNativeInstance;
 extern fn dniDestroy(dni: DawnNativeInstance) void;
+extern fn dniDiscoverDefaultAdapters(dni: DawnNativeInstance) void;
 extern fn dniGetWgpuInstance(dni: DawnNativeInstance) ?wgpu.Instance;
 extern fn dnGetProcs() DawnProcsTable;
 
@@ -1610,6 +1630,7 @@ const SurfaceDescriptorTag = enum {
     windows_hwnd,
     xlib,
     wayland,
+    android_native_window,
     canvas_html,
 };
 
@@ -1633,6 +1654,10 @@ const SurfaceDescriptor = union(SurfaceDescriptorTag) {
         display: *anyopaque,
         surface: *anyopaque,
     },
+    android_native_window: struct {
+        label: ?[*:0]const u8 = null,
+        window: *anyopaque,
+    },
     canvas_html: struct {
         label: ?[*:0]const u8 = null,
         selector: [*:0]const u8,
@@ -1650,7 +1675,7 @@ fn isLinuxDesktopLike(tag: std.Target.Os.Tag) bool {
     };
 }
 
-fn createSurfaceForWindow(instance: wgpu.Instance, window_provider: WindowProvider) wgpu.Surface {
+fn createSurfaceForWindow(instance: wgpu.Instance, window_provider: WindowProvider) !wgpu.Surface {
     const os_tag = @import("builtin").target.os.tag;
 
     const descriptor = switch (os_tag) {
@@ -1688,7 +1713,18 @@ fn createSurfaceForWindow(instance: wgpu.Instance, window_provider: WindowProvid
                 .selector = "#canvas", // TODO: can this be somehow exposed through api?
             },
         },
-        else => if (isLinuxDesktopLike(os_tag)) linux: {
+        .linux => if (@import("builtin").target.abi.isAndroid()) android: {
+            const native_window = window_provider.getAndroidNativeWindow() orelse {
+                std.log.err("[zgpu] createSurfaceForWindow: missing Android native window", .{});
+                return error.NoAndroidNativeWindow;
+            };
+            break :android SurfaceDescriptor{
+            .android_native_window = .{
+                .label = "basic surface",
+                .window = native_window,
+            },
+        };
+        } else if (isLinuxDesktopLike(os_tag)) linux: {
             if (window_provider.getWaylandDisplay()) |wl_display| {
                 break :linux SurfaceDescriptor{
                     .wayland = .{
@@ -1707,6 +1743,7 @@ fn createSurfaceForWindow(instance: wgpu.Instance, window_provider: WindowProvid
                 };
             }
         } else unreachable,
+        else => unreachable,
     };
 
     return switch (descriptor) {
@@ -1748,6 +1785,16 @@ fn createSurfaceForWindow(instance: wgpu.Instance, window_provider: WindowProvid
             desc.chain.struct_type = .surface_descriptor_from_wayland_surface;
             desc.display = src.display;
             desc.surface = src.surface;
+            break :blk instance.createSurface(.{
+                .next_in_chain = @ptrCast(&desc),
+                .label = if (src.label) |l| l else null,
+            });
+        },
+        .android_native_window => |src| blk: {
+            var desc: wgpu.SurfaceDescriptorFromAndroidNativeWindow = undefined;
+            desc.chain.next = null;
+            desc.chain.struct_type = .surface_descriptor_from_android_native_window;
+            desc.window = src.window;
             break :blk instance.createSurface(.{
                 .next_in_chain = @ptrCast(&desc),
                 .label = if (src.label) |l| l else null,

--- a/src/ui/app/multi_window_renderer.zig
+++ b/src/ui/app/multi_window_renderer.zig
@@ -119,7 +119,9 @@ pub const WindowSwapchain = struct {
             return;
         }
 
-        const back_view = self.currentTextureViewMaybe(shared) orelse return;
+        const back_view = self.currentTextureViewMaybe(shared) orelse {
+            return;
+        };
         defer back_view.release();
 
         const encoder = gctx.device.createCommandEncoder(null);
@@ -273,6 +275,17 @@ fn createSurfaceForWindow(instance: zgpu.wgpu.Instance, window: *sdl.SDL_Window)
         sdesc.layer = layer;
         return instance.createSurface(.{
             .next_in_chain = @ptrCast(&sdesc),
+            .label = "zui surface",
+        });
+    }
+
+    if (builtin.target.abi.isAndroid()) {
+        var desc: zgpu.wgpu.SurfaceDescriptorFromAndroidNativeWindow = undefined;
+        desc.chain.next = null;
+        desc.chain.struct_type = .surface_descriptor_from_android_native_window;
+        desc.window = sdlGetAndroidNativeWindow(@ptrCast(window));
+        return instance.createSurface(.{
+            .next_in_chain = @ptrCast(&desc),
             .label = "zui surface",
         });
     }


### PR DESCRIPTION
## Summary
- add Android WGPU surface support in zgpu
- switch Android swapchains to gba8_unorm and force Vulkan adapter selection
- avoid building native desktop artifacts inside ziggy-ui when targeting Android

## Verification
- consumed from SpiderApp Android build/install flow
- validated by launching the app on Android after these renderer changes